### PR TITLE
Changed Boost source URL

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -28,9 +28,9 @@ task createNativeDepsDirectories {
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     // Use ZIP version as it's faster this way to selectively extract some parts of the archive
-    src 'https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.zip'
-    // alternative
-    // src 'http://mirror.nienbo.com/boost/boost_1_57_0.zip'
+    src 'http://mirror.nienbo.com/boost/boost_1_57_0.zip'
+    // original link
+    // src 'https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.zip'
     onlyIfNewer true
     overwrite false
     dest new File(downloadsDir, 'boost_1_57_0.zip')


### PR DESCRIPTION
Due to the handshake fail while using original URL we change it to a mirror link.
